### PR TITLE
Add metadata-only transfer capability

### DIFF
--- a/hera_librarian/__init__.py
+++ b/hera_librarian/__init__.py
@@ -455,7 +455,5 @@ class LibrarianClient(object):
     def gather_file_record(self, file_name):
         return self._do_http_post('gather_file_record', file_name=file_name)
 
-    def create_file_record(self, file_name, sourcename):
-        return self._do_http_post(
-            'create_file_record', file_name=file_name, sourcename=sourcename
-        )
+    def create_file_record(self, rec_info):
+        return self._do_http_post('create_file_record', **rec_info)

--- a/hera_librarian/__init__.py
+++ b/hera_librarian/__init__.py
@@ -451,3 +451,11 @@ class LibrarianClient(object):
             search=search,
             output_format='obs-listing-json',
         )
+
+    def gather_file_record(self, file_name):
+        return self._do_http_post('gather_file_record', file_name=file_name)
+
+    def create_file_record(self, file_name, sourcename):
+        return self._do_http_post(
+            'create_file_record', file_name=file_name, sourcename=sourcename
+        )

--- a/hera_librarian/base_store.py
+++ b/hera_librarian/base_store.py
@@ -142,7 +142,7 @@ class BaseStore(object):
             'rsync',
             '-aP',
             '-e',
-            'ssh -c aes128-ctr -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no',
+            'ssh -c aes256-gcm@openssh.com -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no',
             local_path + local_suffix,
             '%s:%s' % (self.ssh_host, self._path(store_path))
         ]

--- a/hera_librarian/cli.py
+++ b/hera_librarian/cli.py
@@ -187,7 +187,7 @@ def config_add_file_event_subparser(sub_parsers):
 
     # add sub parser
     sp = sub_parsers.add_parser("add-file-event", description=doc, help=hlp)
-    sp.add_argument("connection_name", metavar="CONNECTION-NAME", type=str,
+    sp.add_argument("conn_name", metavar="CONNECTION-NAME", type=str,
                     help=_conn_name_help)
     sp.add_argument("file_path", metavar="PATH/TO/FILE", type=str,
                     help="The path to file in librarian.")
@@ -209,7 +209,7 @@ def config_add_obs_subparser(sub_parsers):
 
     # add sub parser
     sp = sub_parsers.add_parser("add-obs", description=doc, help=hlp)
-    sp.add_argument("connection_name", metavar="CONNECTION-NAME", type=str,
+    sp.add_argument("conn_name", metavar="CONNECTION-NAME", type=str,
                     help=_conn_name_help)
     sp.add_argument("store_name", metavar="NAME",
                     help="The 'store' name under which the Librarian knows this computer.")

--- a/hera_librarian/cli.py
+++ b/hera_librarian/cli.py
@@ -728,7 +728,7 @@ def copy_metadata(args):
 
     # ...and upload it to dest
     try:
-        dest_client.create_file_record(args.file_name, args.source_conn_name)
+        dest_client.create_file_record(rec_info)
     except RPCError as e:
         die("uploading metadata failed: {}".format(e))
 

--- a/librarian_server/store.py
+++ b/librarian_server/store.py
@@ -699,6 +699,35 @@ def launch_file_copy(args, sourcename=None):
     return {}
 
 
+@app.route('/api/gather_file_record', methods=['GET', 'POST'])
+@json_api
+def gather_file_record(args):
+    """Get the record info for a file.
+
+    """
+    from .file import File
+    from .misc import gather_records
+
+    file_name = required_arg(args, str, "file_name")
+    file = File.query.get(file_name)
+    rec_info = gather_records(file)
+
+    return rec_info
+
+
+@app.route('/api/create_file_record', methods=['GET', 'POST'])
+@json_api
+def create_file_record(args, sourcename=None):
+    """Create file records.
+
+    """
+    from .misc import create_records
+
+    create_records(args, sourcename)
+
+    return {}
+
+
 # Offloading files. This functionality was developed for a time when we had to
 # use the RTP "still" machines as temporary emergency Librarian stores. After
 # the emergency was over, we wanted to transfer their files back to the main

--- a/librarian_server/store.py
+++ b/librarian_server/store.py
@@ -710,6 +710,9 @@ def gather_file_record(args, sourcename=None):
 
     file_name = required_arg(args, str, "file_name")
     file = File.query.get(file_name)
+    if file is None:
+        raise ServerError('no file with that name found')
+
     rec_info = gather_records(file)
 
     return rec_info

--- a/librarian_server/store.py
+++ b/librarian_server/store.py
@@ -630,7 +630,7 @@ def launch_copy_by_file_name(
     rec_info = gather_records(file)
 
     # Figure out if we should try to use globus or not
-    if app.config["use_globus"]:
+    if app.config.get("use_globus", False):
         source_endpoint_id = app.config.get("globus_endpoint_id", None)
         try:
             client_id = app.config["globus_client_id"]
@@ -701,7 +701,7 @@ def launch_file_copy(args, sourcename=None):
 
 @app.route('/api/gather_file_record', methods=['GET', 'POST'])
 @json_api
-def gather_file_record(args):
+def gather_file_record(args, sourcename=None):
     """Get the record info for a file.
 
     """


### PR DESCRIPTION
This PR adds the option of transferring only the File metadata from one librarian server to another. This is necessary to support the SneakerNet as currently envisioned.