### PR TITLE
Update for Globus SDKv3

### DIFF
--- a/hera_librarian/base_store.py
+++ b/hera_librarian/base_store.py
@@ -207,7 +207,7 @@ class BaseStore(object):
         """
         try:
             import globus_sdk
-            from globus_sdk.exc import AuthAPIError
+            from globus_sdk.services.auth.errors import AuthAPIError
         except ModuleNotFoundError:
             raise RPCError(
                 "globus_sdk import",

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ although those modules are not installed in a standard ``pip install``.
     ],
     extras_require={
         "server": server_reqs,
-        "globus": globus_reqs
+        "globus": globus_reqs,
         "all": all_reqs,
     },
     scripts=[

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,28 @@ package_name = "hera_librarian"
 
 packages = find_packages(exclude=["*.tests"])
 
+server_reqs = [
+    "aipy",
+    "alembic",
+    "astropy>=2.0",
+    "flask>=2.0",
+    "flask_sqlalchemy",
+    "hera-librarian",
+    "numpy",
+    "psycopg2",
+    "pytz",
+    "pyuvdata",
+    "requests",
+    "requests-oauth2",
+    "sqlalchemy>=1.4.0",
+    "tornado",
+]
+
+globus_reqs = [
+    "globus-sdk>=3.0,<4.0",
+]
+
+all_reqs = server_reqs + globus_reqs
 
 setup(
     name=package_name,
@@ -36,21 +58,9 @@ although those modules are not installed in a standard ``pip install``.
         "Topic :: Scientific/Engineering :: Astronomy",
     ],
     extras_require={
-        "server": [
-            "aipy",
-            "alembic",
-            "astropy >=2.0",
-            "flask",
-            "flask-sqlalchemy",
-            "hera-librarian",
-            "numpy",
-            "psycopg2",  # FIXME: only of using Postgres
-            "pytz",
-            "pyuvdata",
-            "requests",
-            "requests-oauth2",
-            "sqlalchemy",
-        ]
+        "server": server_reqs,
+        "globus": globus_reqs
+        "all": all_reqs,
     },
     scripts=[
         "scripts/librarian_stream_file_or_directory.sh",


### PR DESCRIPTION
This PR updates the Globus API calls to reflect the latest version of the Globus library (v3.15.0 at time of writing). This should make it so we can deploy using the latest interface at site and at NERSC.