### PR TITLE
Clean up __init__ in librarian_server.

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -18,8 +18,6 @@ from logging.config import fileConfig
 config = context.config
 fileConfig(config.config_file_name)
 
-from librarian_server import app, engine
-
 from librarian_server.settings import server_settings
 from librarian_server.database import Base, engine
 
@@ -37,9 +35,8 @@ def run_migrations_offline():
         render_as_batch=True,
     )
 
-    with app.app_context():
-        with context.begin_transaction():
-            context.run_migrations()
+    with context.begin_transaction():
+        context.run_migrations()
 
 
 def run_migrations_online():

--- a/librarian_server/__init__.py
+++ b/librarian_server/__init__.py
@@ -5,23 +5,23 @@ We have moved from Flask to FastAPI to ensure that web requests can be performed
 asynchronously, and that background tasks can work on any available ASGI server.
 """
 
-import os
-
 from .settings import server_settings
-from .logger import log
-from .database import engine, session
-
 from fastapi import FastAPI
 
-log.info("Starting Librarian v2.0 server.")
-log.debug("Creating FastAPI app instance.")
+def main() -> FastAPI:
+    from .logger import log
 
-app = FastAPI()
+    log.info("Starting Librarian v2.0 server.")
+    log.debug("Creating FastAPI app instance.")
 
-log.debug("Adding API router.")
+    app = FastAPI()
 
-from .api import upload_router, ping_router, clone_router
+    log.debug("Adding API router.")
 
-app.include_router(upload_router)
-app.include_router(ping_router)
-app.include_router(clone_router)
+    from .api import upload_router, ping_router, clone_router
+
+    app.include_router(upload_router)
+    app.include_router(ping_router)
+    app.include_router(clone_router)
+
+    return app

--- a/librarian_server_scripts/librarian_server_start.py
+++ b/librarian_server_scripts/librarian_server_start.py
@@ -75,7 +75,7 @@ def main():
     import uvicorn
 
     uvicorn.run(
-        "librarian_server:app",
+        "librarian_server:main",
         port=server_settings.port,
         log_level=server_settings.log_level.lower(),
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,11 +76,10 @@ def test_server(tmp_path_factory):
     import importlib
 
     import librarian_server
+    import librarian_server.database
 
-    importlib.reload(librarian_server)
-
-    app = librarian_server.app
-    session = librarian_server.session
+    app = librarian_server.main()
+    session = librarian_server.database.session
 
     # Need to add our stores...
     from librarian_server.orm import StoreMetadata


### PR DESCRIPTION
Cleans up the __init__.py server component so that we do not create FastAPI objects and database sessions on import.