### PR TITLE
Refactor file upload code and handle errors

### DIFF
--- a/hera_librarian/client.py
+++ b/hera_librarian/client.py
@@ -222,6 +222,7 @@ class LibrarianClient:
                 suggested_remedy=response_json.get(
                     "suggested_remedy", "<no suggested remedy provided>"
                 ),
+                full_response=response_json,
             )
 
         if response is None:

--- a/hera_librarian/exceptions.py
+++ b/hera_librarian/exceptions.py
@@ -4,7 +4,7 @@ Exceptions for the hera_librarian client library.
 
 
 class LibrarianHTTPError(Exception):
-    def __init__(self, url, status_code, reason, suggested_remedy):
+    def __init__(self, url, status_code, reason, suggested_remedy, full_response=None):
         super(LibrarianHTTPError, self).__init__(
             f"HTTP request to {url} failed with status code {status_code} and reason {reason}."
         )
@@ -12,6 +12,7 @@ class LibrarianHTTPError(Exception):
         self.status_code = status_code
         self.reason = reason
         self.suggested_remedy = suggested_remedy
+        self.full_response = full_response
 
 
 class LibrarianError(Exception):

--- a/hera_librarian/exceptions.py
+++ b/hera_librarian/exceptions.py
@@ -15,6 +15,14 @@ class LibrarianHTTPError(Exception):
         self.full_response = full_response
 
 
+class LibrarianTimeoutError(Exception):
+    def __init__(self, url):
+        super(LibrarianTimeoutError, self).__init__(
+            f"HTTP request to {url} timed out or took too many retries."
+        )
+        self.url = url
+
+
 class LibrarianError(Exception):
     def __init__(self, message):
         super(LibrarianError, self).__init__(message)

--- a/librarian_background/__init__.py
+++ b/librarian_background/__init__.py
@@ -25,6 +25,7 @@ def background(run_once: bool = False):
         + background_settings.recieve_clone
         + background_settings.consume_queue
         + background_settings.check_consumed_queue
+        + background_settings.outgoing_transfer_hypervisor
     )
 
     for task in all_tasks:

--- a/librarian_background/hypervisor.py
+++ b/librarian_background/hypervisor.py
@@ -1,0 +1,205 @@
+"""
+The hypervisor task that checks on the status of outgoing transfers.
+
+If they are stale, we call up the downstream librarian to ask for an 
+update on their status. This can lead to a:
+
+a) Failure of the outgoing transfer
+b) Successful transfer, if the file is found on the downstream
+"""
+
+import datetime
+
+from sqlalchemy.orm import Session
+
+from hera_librarian.exceptions import LibrarianHTTPError, LibrarianTimeoutError
+from librarian_server.database import get_session
+from librarian_server.logger import ErrorCategory, ErrorSeverity, log_to_database
+from librarian_server.orm import (
+    Librarian,
+    OutgoingTransfer,
+    RemoteInstance,
+    TransferStatus,
+)
+
+from .task import Task
+
+
+def get_stale_of_type(session: Session, age_in_days: int, transfer_type: object):
+    """
+    Get the stale transfers of a given type.
+    """
+
+    # Get the stale outgoing transfers
+    stale_since = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(
+        days=age_in_days
+    )
+
+    transfer_stmt = session.query(transfer_type)
+
+    transfer_stmt = transfer_stmt.where(transfer_type.start_time < stale_since)
+
+    transfer_stmt = transfer_stmt.where(
+        transfer_type.status.in_(
+            [TransferStatus.INITIATED, TransferStatus.ONGOING, TransferStatus.STAGED]
+        )
+    )
+
+    return session.execute(transfer_stmt).scalars().all()
+
+
+def handle_stale_outgoing_transfer(
+    session: Session, transfer: OutgoingTransfer
+) -> bool:
+    """
+    In all cases, we ask if the downstream has the file. If it does, we mark our
+    transfer as completed as if we just completed a transfer, and mark our
+    OutgoingTransfer as complete.
+
+    If the downstream does not have the file, we will ask the downstream to cancel
+    its incoming transfer.
+    """
+
+    downstream_librarian = (
+        session.query(Librarian).filter_by(name=transfer.destination).one_or_none()
+    )
+
+    if not downstream_librarian:
+        log_to_database(
+            severity=ErrorSeverity.ERROR,
+            category=ErrorCategory.DATA_INTEGRITY,
+            message=f"Downstream librarian {transfer.destination} not found",
+            session=session,
+        )
+
+        transfer.fail_transfer(session=session, commit=False)
+
+        return False
+
+    client = downstream_librarian.client()
+
+    expected_file_name = transfer.file.name
+    expected_file_checksum = transfer.file.checksum
+
+    try:
+        potential_files = client.search_files(
+            name=expected_file_name,
+        )
+    except (LibrarianHTTPError, LibrarianTimeoutError) as e:
+        log_to_database(
+            severity=ErrorSeverity.ERROR,
+            category=ErrorCategory.LIBRARIAN_NETWORK_AVAILABILITY,
+            message=(
+                f"Unacceptable error when trying to check if librarian {transfer.destination}"
+                f"has file {expected_file_name} with exception {e}."
+            ),
+            session=session,
+        )
+        return False
+
+    if not potential_files:
+        # The downstream does not have the file. We should cancel the transfer.
+        log_to_database(
+            severity=ErrorSeverity.ERROR,
+            category=ErrorCategory.DATA_INTEGRITY,
+            message=f"Downstream librarian {transfer.destination} does "
+            f"not have file {expected_file_name} and the transfer is stale. "
+            "Cancelling the transfer.",
+            session=session,
+        )
+
+        transfer.fail_transfer(session=session, commit=False)
+
+        return False
+
+    available_checksums = {f.checksum for f in potential_files}
+    available_store_ids = {i.store_id for f in potential_files for i in f.instances}
+
+    if len(available_checksums) != 1:
+        log_to_database(
+            severity=ErrorSeverity.ERROR,
+            category=ErrorCategory.DATA_INTEGRITY,
+            message=f"Multiple (or zero, actual {len(available_checksums)}) checksums "
+            f"found for file {expected_file_name} "
+            f"on downstream librarian {transfer.destination}.",
+            session=session,
+        )
+
+        transfer.fail_transfer(session=session, commit=False)
+
+        return False
+
+    available_checksum = available_checksums.pop()
+    available_store_id = available_store_ids.pop()
+
+    if available_checksum != expected_file_checksum:
+        log_to_database(
+            severity=ErrorSeverity.ERROR,
+            category=ErrorCategory.DATA_INTEGRITY,
+            message=f"Checksum mismatch for file {expected_file_name} "
+            f"on downstream librarian {transfer.destination}.",
+            session=session,
+        )
+
+        transfer.fail_transfer(session=session, commit=False)
+
+        return False
+
+    # If we made it here, we succeeded, we just never heard back!
+
+    remote_instance = RemoteInstance.new_instance(
+        file=transfer.file,
+        store_id=available_store_id,
+        librarian=downstream_librarian,
+    )
+
+    session.add(remote_instance)
+    transfer.status = TransferStatus.COMPLETED
+
+    session.commit()
+
+    log_to_database(
+        severity=ErrorSeverity.INFO,
+        category=ErrorCategory.TRANSFER,
+        message=(
+            f"Successfully registered remote instance for {transfer.destination} and "
+            f"transfer {transfer.id} based upon stale transfer with "
+            f"status {transfer.status}."
+        ),
+        session=session,
+    )
+
+    return True
+
+
+class OutgoingTransferHypervisor(Task):
+    """
+    Checks in on stale outgoing transfers.
+    """
+
+    age_in_days: int
+    "The age in days of the outgoing transfer before we consider it stale."
+
+    def on_call(self):
+        with get_session() as session:
+            return self.core(session=session)
+
+    def core(self, session):
+        """
+        Checks for stale outgoing transfers and updates their status.
+        """
+
+        start_time = datetime.datetime.now(datetime.timezone.utc)
+        end_time = start_time + self.soft_timeout
+
+        stale_transfers = get_stale_of_type(session, self.age_in_days, OutgoingTransfer)
+
+        for transfer in stale_transfers:
+            current_time = datetime.datetime.now(datetime.timezone.utc)
+
+            if current_time > end_time:
+                return False
+
+            handle_stale_outgoing_transfer(session, transfer)
+
+        return True

--- a/librarian_background/send_clone.py
+++ b/librarian_background/send_clone.py
@@ -591,10 +591,6 @@ class SendClone(Task):
 
         file_stmt = file_stmt.where(File.name.not_in(outgoing_transfer_stmt))
 
-        import pdb
-
-        pdb.set_trace()
-
         files_without_remote_instances: list[File] = (
             session.execute(file_stmt).scalars().all()
         )

--- a/librarian_background/send_clone.py
+++ b/librarian_background/send_clone.py
@@ -587,9 +587,13 @@ class SendClone(Task):
             )
         )
 
-        file_stmt = file_stmt.where(
-            File.name.not_in(remote_instances_stmt).not_in(outgoing_transfer_stmt)
-        )
+        file_stmt = file_stmt.where(File.name.not_in(remote_instances_stmt))
+
+        file_stmt = file_stmt.where(File.name.not_in(outgoing_transfer_stmt))
+
+        import pdb
+
+        pdb.set_trace()
 
         files_without_remote_instances: list[File] = (
             session.execute(file_stmt).scalars().all()

--- a/librarian_background/settings.py
+++ b/librarian_background/settings.py
@@ -12,6 +12,7 @@ from pydantic import BaseModel, ValidationError
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from hera_librarian.deletion import DeletionPolicy
+from librarian_background.hypervisor import OutgoingTransferHypervisor
 
 from .check_integrity import CheckIntegrity
 from .create_clone import CreateLocalClone
@@ -175,6 +176,23 @@ class CheckConsumedQueueSettings(BackgroundTaskSettings):
         )
 
 
+class OutgoingTransferHypevrisorSettings(BackgroundTaskSettings):
+    """
+    Settings for the hypervisor task.
+    """
+
+    age_in_days: int
+    "The age of the items to check, in days."
+
+    @property
+    def task(self) -> OutgoingTransferHypervisor:
+        return OutgoingTransferHypervisor(
+            name=self.task_name,
+            age_in_days=self.age_in_days,
+            soft_timeout=self.soft_timeout,
+        )
+
+
 class BackgroundSettings(BaseSettings):
     """
     Background task settings, configurable.
@@ -199,6 +217,8 @@ class BackgroundSettings(BaseSettings):
 
     check_consumed_queue: list[CheckConsumedQueueSettings] = []
     "Settings for the check consumed queue task."
+
+    outgoing_transfer_hypervisor: list[OutgoingTransferHypevrisorSettings] = []
 
     # Global settings:
 

--- a/librarian_server/__init__.py
+++ b/librarian_server/__init__.py
@@ -5,9 +5,24 @@ We have moved from Flask to FastAPI to ensure that web requests can be performed
 asynchronously, and that background tasks can work on any available ASGI server.
 """
 
+from contextlib import asynccontextmanager
+
 from fastapi import FastAPI
 
 from .settings import server_settings
+
+
+@asynccontextmanager
+def slack_post_at_startup_shutdown(app: FastAPI):
+    """
+    Lifespan event that posts to the slack hook once
+    the FastAPI server starts up and shuts down.
+    """
+    from .logger import post_text_event_to_slack
+
+    post_text_event_to_slack("Librarian server starting up")
+    yield
+    post_text_event_to_slack("Librarian shutting down")
 
 
 def main() -> FastAPI:
@@ -20,6 +35,7 @@ def main() -> FastAPI:
         title=server_settings.displayed_site_name,
         description=server_settings.displayed_site_description,
         openapi_url="/api/v2/openapi.json" if server_settings.debug else None,
+        # lifespan=slack_post_at_startup_shutdown,
     )
 
     log.debug("Adding API router.")

--- a/librarian_server/__init__.py
+++ b/librarian_server/__init__.py
@@ -35,7 +35,7 @@ def main() -> FastAPI:
         title=server_settings.displayed_site_name,
         description=server_settings.displayed_site_description,
         openapi_url="/api/v2/openapi.json" if server_settings.debug else None,
-        # lifespan=slack_post_at_startup_shutdown,
+        lifespan=slack_post_at_startup_shutdown,
     )
 
     log.debug("Adding API router.")

--- a/librarian_server/api/search.py
+++ b/librarian_server/api/search.py
@@ -111,6 +111,7 @@ def file(
                 instances=[
                     InstanceSearchResponse(
                         path=instance.path,
+                        store_id=instance.store_id,
                         deletion_policy=instance.deletion_policy,
                         created_time=instance.created_time,
                         available=instance.available,

--- a/librarian_server/api/upload.py
+++ b/librarian_server/api/upload.py
@@ -235,7 +235,7 @@ def commit(
             session=session,
         )
     except FileNotFoundError:
-        log.debug(
+        log.error(
             f"File {request.staging_location} not found in staging area. Returning error"
         )
         response.status_code = status.HTTP_404_NOT_FOUND
@@ -246,7 +246,7 @@ def commit(
             "contact the administrator of this librarian instance.",
         )
     except FileExistsError:
-        log.debug(
+        log.error(
             f"File {request.destination_location} already exists on store. Returning error."
         )
         response.status_code = status.HTTP_409_CONFLICT
@@ -258,10 +258,10 @@ def commit(
                 "unique filename that does not already exist."
             ),
         )
-    except ValueError:
-        log.debug(
+    except ValueError as e:
+        log.error(
             f"File {request.destination_location} does not have a valid "
-            "checksum or size. Returning error."
+            f"checksum or size. Returning error: {e}"
         )
         response.status_code = status.HTTP_406_NOT_ACCEPTABLE
         return UploadFailedResponse(
@@ -272,7 +272,7 @@ def commit(
     except Exception as e:
         import traceback
 
-        log.debug(
+        log.error(
             "Extremely bad internal server error. Likley a database communication issue. "
             f"Error: {e}, Traceback:\n{traceback.format_exc()}"
         )

--- a/librarian_server/api/upload.py
+++ b/librarian_server/api/upload.py
@@ -230,7 +230,6 @@ def commit(
         # that needs to happen. All we need to do is return the appropriate
         # HTTP response code and data.
         store.ingest_staged_file(
-            request=request,
             transfer=transfer,
             session=session,
         )

--- a/librarian_server/api/upload.py
+++ b/librarian_server/api/upload.py
@@ -10,6 +10,7 @@ from fastapi import APIRouter, Depends, Response, status
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from hera_librarian.deletion import DeletionPolicy
 from hera_librarian.models.uploads import (
     UploadCompletionRequest,
     UploadFailedResponse,
@@ -232,6 +233,7 @@ def commit(
         store.ingest_staged_file(
             transfer=transfer,
             session=session,
+            deletion_policy=DeletionPolicy.from_str(request.deletion_policy),
         )
     except FileNotFoundError:
         log.error(

--- a/librarian_server/logger.py
+++ b/librarian_server/logger.py
@@ -30,6 +30,22 @@ error_severity_to_logging_level = {
 log.debug("Logging set up.")
 
 
+def post_text_event_to_slack(text: str) -> None:
+    log.info(text)
+
+    if not server_settings.slack_webhook_enable:
+        return
+
+    requests.post(
+        server_settings.slack_webhook_enable,
+        json={
+            "username": server_settings.displayed_site_name,
+            "icon_emoji": ":ledger:",
+            "text": text,
+        },
+    )
+
+
 def post_error_to_slack(error: "Error") -> None:
     if not server_settings.slack_webhook_enable:
         return

--- a/librarian_server/orm/storemetadata.py
+++ b/librarian_server/orm/storemetadata.py
@@ -112,7 +112,6 @@ class StoreMetadata(db.Base):
 
     def ingest_staged_file(
         self,
-        request: UploadCompletionRequest,
         transfer: IncomingTransfer,
         session: "Session",
     ) -> Instance:

--- a/librarian_server/stores/core.py
+++ b/librarian_server/stores/core.py
@@ -26,6 +26,40 @@ class CoreStore(BaseModel, abc.ABC):
 
     name: str
 
+    @abc.abstractmethod
+    def resolve_path_store(self, path: Path | str) -> Path:
+        """
+        Resolve a path relative to the store.
+
+        Parameters
+        ----------
+        path : Path
+            Path to resolve.
+
+        Returns
+        -------
+        Path
+            Resolved path.
+        """
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def resolve_path_staging(self, path: Path | str) -> Path:
+        """
+        Resolve a path relative to the staging area.
+
+        Parameters
+        ----------
+        path : Path
+            Path to resolve.
+
+        Returns
+        -------
+        Path
+            Resolved path.
+        """
+        raise NotImplementedError
+
     @property
     @abc.abstractmethod
     def available(self) -> bool:

--- a/librarian_server/stores/local.py
+++ b/librarian_server/stores/local.py
@@ -87,6 +87,12 @@ class LocalStore(CoreStore):
 
         return complete_path
 
+    def resolve_path_store(self, path: Path | str) -> Path:
+        return self._resolved_path_store(Path(path))
+
+    def resolve_path_staging(self, path: Path | str) -> Path:
+        return self._resolved_path_staging(Path(path))
+
     def stage(self, file_size: int, file_name: Path) -> tuple[Path]:
         if file_size > self.free_space:
             raise ValueError("Not enough free space on store")

--- a/tests/integration_test/test_send_queue.py
+++ b/tests/integration_test/test_send_queue.py
@@ -288,7 +288,7 @@ def test_send_from_existing_file_row(
         )
 
         for transfer in incoming_transfers:
-            assert Path(transfer.staging_path).exists()
+            assert transfer.status == TransferStatus.STAGED
 
     # Force downstream to execute their background tasks.
     from librarian_background.recieve_clone import RecieveClone

--- a/tests/integration_test/test_send_queue.py
+++ b/tests/integration_test/test_send_queue.py
@@ -374,7 +374,10 @@ def test_use_batch_to_call_librarian(
     from hera_librarian import LibrarianClient
 
     fake_client = LibrarianClient(
-        host="http://nowhere.com", port=12345, user="404", password="notfound"
+        host="http://localhost",
+        port=test_server_with_many_files_and_errors[2].id,
+        user="404",
+        password="notfound",
     )
 
     from librarian_background.send_clone import use_batch_to_call_librarian
@@ -436,7 +439,10 @@ def test_create_send_queue_item_no_transfer_providers(
     from hera_librarian import LibrarianClient
 
     fake_client = LibrarianClient(
-        host="http://nowhere.com", port=12345, user="404", password="notfound"
+        host="http://localhost",
+        port=test_server_with_many_files_and_errors[2].id,
+        user="404",
+        password="notfound",
     )
 
     from librarian_background.send_clone import use_batch_to_call_librarian
@@ -529,7 +535,10 @@ def test_create_send_queue_item_no_availability_of_transfer_manager(
     from hera_librarian import LibrarianClient
 
     fake_client = LibrarianClient(
-        host="http://nowhere.com", port=12345, user="404", password="notfound"
+        host="http://localhost",
+        port=test_server_with_many_files_and_errors[2].id,
+        user="404",
+        password="notfound",
     )
 
     from librarian_background.send_clone import use_batch_to_call_librarian


### PR DESCRIPTION
- Modify upload code to not rely on the underlying request

- Remove request parameter to ingest staged file

- Refactor recv clone to use ingest staged

- Handle the case where downstream already has our file

- Add timeout errors

- Minor logic bug; need double WHERE not double NOT IN

- Don't leave PDB in prod code

