### PR TITLE
Use xxh3 for checksumming

### DIFF
--- a/hera_librarian/async_transfers/globus.py
+++ b/hera_librarian/async_transfers/globus.py
@@ -118,7 +118,7 @@ class GlobusAsyncTransferManager(CoreAsyncTransferManager):
             destination_endpoint=self.destination_endpoint,
             label=label,
             sync_level="exists",
-            verify_checksum=False,  # we do this ourselves
+            verify_checksum=True,  # We do this ourselves, but globus will auto-retry if it files failed files
             preserve_timestamp=True,
             notify_on_succeeded=False,
         )

--- a/hera_librarian/async_transfers/globus.py
+++ b/hera_librarian/async_transfers/globus.py
@@ -118,7 +118,7 @@ class GlobusAsyncTransferManager(CoreAsyncTransferManager):
             destination_endpoint=self.destination_endpoint,
             label=label,
             sync_level="exists",
-            verify_checksum=True,  # We do this ourselves, but globus will auto-retry if it files failed files
+            verify_checksum=True,  # We do this ourselves, but globus will auto-retry if it detects failed files
             preserve_timestamp=True,
             notify_on_succeeded=False,
         )

--- a/hera_librarian/client.py
+++ b/hera_librarian/client.py
@@ -69,7 +69,11 @@ from .models.users import (
     UserAdministrationUpdateRequest,
 )
 from .settings import ClientInfo
-from .utils import get_md5_from_path, get_size_from_path
+from .utils import (
+    get_checksum_from_path,
+    get_hash_function_from_hash,
+    get_size_from_path,
+)
 
 if TYPE_CHECKING:
     from .transfers import CoreTransferManager
@@ -388,7 +392,7 @@ class LibrarianClient:
             endpoint="upload/stage",
             request=UploadInitiationRequest(
                 upload_size=get_size_from_path(local_path),
-                upload_checksum=get_md5_from_path(local_path),
+                upload_checksum=get_checksum_from_path(local_path),
                 upload_name=dest_path.name,
                 destination_location=dest_path,
                 uploader=self.user,

--- a/hera_librarian/utils.py
+++ b/hera_librarian/utils.py
@@ -2,10 +2,110 @@
 Useful utilities for files.
 """
 
+import hashlib
+import os
 import os.path
+import re
 from pathlib import Path
 
-from checksumdir import HASH_FUNCS, _filehash, dirhash
+import pkg_resources
+import xxhash
+
+# Here we bundle the source code from checksumdir rather than relying on it as
+# a dependency. Maintenance seems to have ended for checksumdir, and we want access
+# to faster hashing functions
+
+# --- Begin MIT Licensed checksumdir ---
+
+
+__version__ = pkg_resources.require("checksumdir")[0].version
+
+HASH_FUNCS = {
+    "md5": hashlib.md5,
+    "xxh3": xxhash.xxh3_128,
+    "sha1": hashlib.sha1,
+    "sha256": hashlib.sha256,
+    "sha512": hashlib.sha512,
+}
+
+
+def dirhash(
+    dirname,
+    hashfunc="md5",
+    excluded_files=None,
+    ignore_hidden=False,
+    followlinks=False,
+    excluded_extensions=None,
+    include_paths=False,
+):
+    hash_func = HASH_FUNCS.get(hashfunc)
+    if not hash_func:
+        raise NotImplementedError("{} not implemented.".format(hashfunc))
+
+    if not excluded_files:
+        excluded_files = []
+
+    if not excluded_extensions:
+        excluded_extensions = []
+
+    if not os.path.isdir(dirname):
+        raise TypeError("{} is not a directory.".format(dirname))
+
+    hashvalues = []
+    for root, dirs, files in os.walk(dirname, topdown=True, followlinks=followlinks):
+        if ignore_hidden and re.search(r"/\.", root):
+            continue
+
+        dirs.sort()
+        files.sort()
+
+        for fname in files:
+            if ignore_hidden and fname.startswith("."):
+                continue
+
+            if fname.split(".")[-1:][0] in excluded_extensions:
+                continue
+
+            if fname in excluded_files:
+                continue
+
+            hashvalues.append(_filehash(os.path.join(root, fname), hash_func))
+
+            if include_paths:
+                hasher = hash_func()
+                # get the resulting relative path into array of elements
+                path_list = os.path.relpath(os.path.join(root, fname)).split(os.sep)
+                # compute the hash on joined list, removes all os specific separators
+                hasher.update("".join(path_list).encode("utf-8"))
+                hashvalues.append(hasher.hexdigest())
+
+    return _reduce_hash(hashvalues, hash_func)
+
+
+def _filehash(filepath, hashfunc):
+    hasher = hashfunc()
+    blocksize = 64 * 1024
+
+    if not os.path.exists(filepath):
+        return hasher.hexdigest()
+
+    with open(filepath, "rb") as fp:
+        while True:
+            data = fp.read(blocksize)
+            if not data:
+                break
+            hasher.update(data)
+    return hasher.hexdigest()
+
+
+def _reduce_hash(hashlist, hashfunc):
+    hasher = hashfunc()
+    for hashvalue in sorted(hashlist):
+        hasher.update(hashvalue.encode("utf-8"))
+    return hasher.hexdigest()
+
+
+# --- end checksumdir ---
 
 
 def get_type_from_path(path):
@@ -31,6 +131,66 @@ def get_md5_from_path(path):
     else:
         # Just a single file. That's fine!
         return _filehash(path, HASH_FUNCS["md5"])
+
+
+def get_checksum_from_path(path: str | Path, hash_function: str = "xxh3") -> str:
+    """
+    Compute the checksum of a file from a path. This allows you to select
+    the underlying checksum function, which is by default the very fast
+    xxh3. Using this function, you also always have the hashing function
+    pre-pended to the hash itself.
+    """
+
+    path = Path(path).resolve()
+
+    if path.is_dir():
+        return hash_function + ":::" + dirhash(path, hash_function)
+    else:
+        # Just a single file. That's fine!
+        return hash_function + ":::" + _filehash(path, HASH_FUNCS[hash_function])
+
+
+def get_hash_function_from_hash(hash: str) -> str:
+    """
+    Searches the hash for the hash function. If none is found, then we return
+    the old default (md5).
+    """
+
+    for hash_func_name in HASH_FUNCS.keys():
+        if hash.startswith(hash_func_name + ":::"):
+            return hash_func_name
+
+    return "md5"
+
+
+def get_base_hash_from_hash(hash: str) -> str:
+    """
+    Gets the 'base' hash without our hashfunc::: prepended.
+    """
+
+    for hash_func_name in HASH_FUNCS.keys():
+        if hash.startswith(hash_func_name + ":::"):
+            return hash.replace(hash_func_name + ":::", "")
+
+    return hash
+
+
+def compare_checksums(a: str, b: str) -> bool:
+    """
+    Compares two checksums to see if they match.
+
+    Raises a ValueError if a, b were checksummed with differing algorithms.
+    """
+
+    hf_a = get_hash_function_from_hash(a)
+    hf_b = get_hash_function_from_hash(b)
+
+    if hf_a != hf_b:
+        raise ValueError(
+            f"Checksums {a} and {b} were created with differing has functions!"
+        )
+
+    return get_base_hash_from_hash(a) == get_base_hash_from_hash(b)
 
 
 def get_size_from_path(path):

--- a/hera_librarian/utils.py
+++ b/hera_librarian/utils.py
@@ -18,8 +18,6 @@ import xxhash
 # --- Begin MIT Licensed checksumdir ---
 
 
-__version__ = pkg_resources.require("checksumdir")[0].version
-
 HASH_FUNCS = {
     "md5": hashlib.md5,
     "xxh3": xxhash.xxh3_128,

--- a/librarian_background/create_clone.py
+++ b/librarian_background/create_clone.py
@@ -12,6 +12,7 @@ from schedule import CancelJob
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from hera_librarian.utils import compare_checksums, get_hash_function_from_hash
 from librarian_server.database import get_session
 from librarian_server.logger import ErrorCategory, ErrorSeverity, log_to_database
 from librarian_server.orm import CloneTransfer, Instance, StoreMetadata, TransferStatus
@@ -302,14 +303,17 @@ class CreateLocalClone(Task):
 
             # Now we can commit the file to the store.
             try:
-                path_info = store_to.store_manager.path_info(staged_path)
+                hash_function = get_hash_function_from_hash(instance.file.checksum)
+                path_info = store_to.store_manager.path_info(
+                    staged_path, hash_function=hash_function
+                )
 
-                if path_info.md5 != instance.file.checksum:
+                if not compare_checksums(path_info.checksum, instance.file.checksum):
                     log_to_database(
                         severity=ErrorSeverity.ERROR,
                         category=ErrorCategory.DATA_INTEGRITY,
                         message=f"File {instance.path} on store {store_to} has an incorrect checksum. "
-                        f"Expected {instance.file.checksum}, got {path_info.md5}. (Instance {instance.id})",
+                        f"Expected {instance.file.checksum}, got {path_info.checksum}. (Instance {instance.id})",
                         session=session,
                     )
 

--- a/librarian_background/hypervisor.py
+++ b/librarian_background/hypervisor.py
@@ -13,6 +13,7 @@ import datetime
 from sqlalchemy.orm import Session
 
 from hera_librarian.exceptions import LibrarianHTTPError, LibrarianTimeoutError
+from hera_librarian.utils import compare_checksums
 from librarian_server.database import get_session
 from librarian_server.logger import ErrorCategory, ErrorSeverity, log_to_database
 from librarian_server.orm import (
@@ -132,7 +133,7 @@ def handle_stale_outgoing_transfer(
     available_checksum = available_checksums.pop()
     available_store_id = available_store_ids.pop()
 
-    if available_checksum != expected_file_checksum:
+    if not compare_checksums(available_checksum, expected_file_checksum):
         log_to_database(
             severity=ErrorSeverity.ERROR,
             category=ErrorCategory.DATA_INTEGRITY,

--- a/librarian_server/api/upload.py
+++ b/librarian_server/api/upload.py
@@ -266,7 +266,7 @@ def commit(
         )
         response.status_code = status.HTTP_406_NOT_ACCEPTABLE
         return UploadFailedResponse(
-            reason="File does not have a valid checksum or size.",
+            reason=f"File does not have a valid checksum or size",
             suggested_remedy="Try to transfer the file again. If the problem persists, "
             "contact the administrator of this librarian instance.",
         )

--- a/librarian_server/api/upload.py
+++ b/librarian_server/api/upload.py
@@ -266,7 +266,7 @@ def commit(
         )
         response.status_code = status.HTTP_406_NOT_ACCEPTABLE
         return UploadFailedResponse(
-            reason=f"File does not have a valid checksum or size",
+            reason="File does not have a valid checksum or size",
             suggested_remedy="Try to transfer the file again. If the problem persists, "
             "contact the administrator of this librarian instance.",
         )

--- a/librarian_server/stores/core.py
+++ b/librarian_server/stores/core.py
@@ -155,7 +155,7 @@ class CoreStore(BaseModel, abc.ABC):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def path_info(self, path: Path) -> PathInfo:
+    def path_info(self, path: Path, hash_function: str = "xxh3") -> PathInfo:
         """
         Get information about a file or directory at a path.
 
@@ -163,6 +163,8 @@ class CoreStore(BaseModel, abc.ABC):
         ----------
         path : Path
             Path to do this at.
+        hash_function: str
+            The hashing function chosen for checksuming this data.
 
         Returns
         -------

--- a/librarian_server/stores/local.py
+++ b/librarian_server/stores/local.py
@@ -11,7 +11,8 @@ from pathlib import Path
 
 from hera_librarian.transfers.core import CoreTransferManager
 from hera_librarian.utils import (
-    get_md5_from_path,
+    get_checksum_from_path,
+    get_hash_function_from_hash,
     get_size_from_path,
     get_type_from_path,
 )
@@ -231,7 +232,7 @@ class LocalStore(CoreStore):
 
         return resolved_path
 
-    def path_info(self, path: Path) -> PathInfo:
+    def path_info(self, path: Path, hash_function: str = "xxh3") -> PathInfo:
         # Promote path to object if required
         path = Path(path)
 
@@ -242,7 +243,7 @@ class LocalStore(CoreStore):
             # Use the old functions for consistency.
             path=path,
             filetype=get_type_from_path(str(path)),
-            md5=get_md5_from_path(path),
+            checksum=get_checksum_from_path(path, hash_function=hash_function),
             size=get_size_from_path(path),
         )
 

--- a/librarian_server/stores/pathinfo.py
+++ b/librarian_server/stores/pathinfo.py
@@ -19,8 +19,8 @@ class PathInfo(BaseModel):
     "Path being considered"
     filetype: str
     "File type at the path (e.g. png)"
-    md5: str
-    "MD5 sum of the file at the path"
+    checksum: str
+    "Checksum of the file at the path"
     size: int
     "Size in bytes of the file at the path"
     obsid: Optional[int] = None

--- a/librarian_server_scripts/librarian_server_rebuild_database.py
+++ b/librarian_server_scripts/librarian_server_rebuild_database.py
@@ -3,7 +3,7 @@ Rebuild the librarian database from scratch. Note that you WILL
 lose all:
 
 - Remote instances
-- MD5 Checksums
+- Checksums
 - User information
 """
 
@@ -124,7 +124,7 @@ def ingest_files(file_list: dict[str, Path], store_name: str):
             file = File.new_file(
                 filename=file_name,
                 size=file_path_info.size,
-                checksum=file_path_info.md5,
+                checksum=file_path_info.checksum,
                 uploader="unknown",
                 source="unknown",
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ version = "2.3.1"
 dependencies = [
     "alembic",
     "argon2-cffi",
-    "checksumdir",
+    "xxhash >= 0.8.0",
     "cryptography",
     "fastapi >= 0.108.0",
     "globus-sdk",

--- a/tests/background_unit_test/test_recieve_clone.py
+++ b/tests/background_unit_test/test_recieve_clone.py
@@ -45,7 +45,7 @@ def test_recieve_clone_with_valid(test_client, test_server, test_orm, garbage_fi
         source="test_user",
         upload_name=garbage_file.name,
         transfer_size=info.size,
-        transfer_checksum=info.md5,
+        transfer_checksum=info.checksum,
     )
 
     incoming_transfer.status = test_orm.TransferStatus.STAGED
@@ -88,7 +88,9 @@ def test_recieve_clone_with_valid(test_client, test_server, test_orm, garbage_fi
     assert expected_path.exists()
 
     # Check the file is in the store.
-    assert store.store_manager.path_info(file.instances[0].path).md5 == info.md5
+    assert (
+        store.store_manager.path_info(file.instances[0].path).checksum == info.checksum
+    )
 
     session.get(test_orm.File, "garbage_file.txt").delete(
         session=session, commit=False, force=True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,6 @@ import pytest
 from hera_librarian.client import AdminClient
 from hera_librarian.errors import ErrorCategory, ErrorSeverity
 from hera_librarian.exceptions import LibrarianHTTPError
-from hera_librarian.utils import get_md5_from_path, get_size_from_path
 
 from .server import Server, server_setup
 
@@ -210,6 +209,7 @@ def test_server_with_valid_file(test_server, test_orm):
     file = test_orm.File.new_file(
         filename="example_file.txt",
         size=len(data),
+        # Leave as-is to test auto-selection of md5
         checksum=hashlib.md5(data).hexdigest(),
         uploader="test",
         source="test",
@@ -382,6 +382,7 @@ def test_server_with_many_files_and_errors(test_server, test_orm):
         file = test_orm.File.new_file(
             filename=file_name,
             size=len(data),
+            # Leave as-is to test auto-selection of md5
             checksum=hashlib.md5(data).hexdigest(),
             uploader="test",
             source="test",

--- a/tests/integration_test/test_admin_services.py
+++ b/tests/integration_test/test_admin_services.py
@@ -30,6 +30,7 @@ def test_add_file(
         name="test_upload_without_uploading.txt",
         create_time=garbage_file.stat().st_ctime,
         size=garbage_file.stat().st_size,
+        # Leave this as-is to test 'auto selection' of md5 checksums.
         checksum=get_md5_from_path(full_path),
         uploader="test",
         path=str(full_path),
@@ -61,6 +62,7 @@ def test_add_file(
         name="test_upload_without_uploading.txt",
         create_time=garbage_file.stat().st_ctime,
         size=garbage_file.stat().st_size,
+        # Leave this as-is to test 'auto selection' of md5 checksums.
         checksum=get_md5_from_path(full_path),
         uploader="test",
         path=str(full_path),
@@ -75,6 +77,7 @@ def test_add_file(
             name="test_upload_without_uploading.txt",
             create_time=garbage_file.stat().st_ctime,
             size=garbage_file.stat().st_size,
+            # Leave this as-is to test 'auto selection' of md5 checksums.
             checksum=get_md5_from_path(full_path),
             uploader="test",
             path=str(full_path),
@@ -86,6 +89,7 @@ def test_add_file(
             name="test_upload_without_uploading_but_doesnt_exist.txt",
             create_time=garbage_file.stat().st_ctime,
             size=garbage_file.stat().st_size,
+            # Leave this as-is to test 'auto selection' of md5 checksums.
             checksum=get_md5_from_path(full_path),
             uploader="test",
             path=str(

--- a/tests/server_unit_test/test_admin.py
+++ b/tests/server_unit_test/test_admin.py
@@ -21,7 +21,7 @@ from hera_librarian.models.admin import (
     AdminStoreStateChangeRequest,
     AdminStoreStateChangeResponse,
 )
-from hera_librarian.utils import get_md5_from_path, get_size_from_path
+from hera_librarian.utils import get_checksum_from_path, get_size_from_path
 
 
 def test_add_file(test_client, test_server, garbage_file, test_orm):
@@ -43,7 +43,7 @@ def test_add_file(test_client, test_server, garbage_file, test_orm):
         name="test_upload_without_uploading.txt",
         create_time=garbage_file.stat().st_ctime,
         size=garbage_file.stat().st_size,
-        checksum=get_md5_from_path(full_path),
+        checksum=get_checksum_from_path(full_path),
         uploader="test",
         source="test",
         path=str(full_path),

--- a/tests/server_unit_test/test_clone.py
+++ b/tests/server_unit_test/test_clone.py
@@ -193,6 +193,7 @@ def test_ongoing_transfer(
 
     with open(garbage_file, "rb") as f:
         data = f.read()
+        # Leave as-is to test auto-selection of md5
         checksum = md5(data).hexdigest()
         size = len(data)
 

--- a/tests/server_unit_test/test_upload.py
+++ b/tests/server_unit_test/test_upload.py
@@ -17,7 +17,7 @@ from hera_librarian.models.uploads import (
     UploadInitiationRequest,
     UploadInitiationResponse,
 )
-from hera_librarian.utils import get_md5_from_path, get_size_from_path
+from hera_librarian.utils import get_checksum_from_path, get_size_from_path
 
 from ..server import Server
 
@@ -456,7 +456,7 @@ def test_directory_upload(test_client, test_server, test_orm, tmp_path):
     request = UploadInitiationRequest(
         destination_location="test_directory",
         upload_size=get_size_from_path(path),
-        upload_checksum=get_md5_from_path(path),
+        upload_checksum=get_checksum_from_path(path),
         uploader="test",
         upload_name="test",
     )


### PR DESCRIPTION
Our high-speed transfers are actually limited by the speed at which we can checksum files on the downstream end. This is, at the moment, done in serial.

MD5 was never designed to be a high-speed integrity check, and was initially designed for cryptographic purposes. Here, I've left that as the default (so we do not need to re-checksum all files ingested into older librarians), but we will now by default use xxh3 which is significantly more performant.

I've also told globus to do its own checksumming. We may as well get a re-transferred version 'for free' without having to spin around in the librarian.