### PR TITLE
Remove globus authorizer from async transfer object

### DIFF
--- a/hera_librarian/async_transfers/globus.py
+++ b/hera_librarian/async_transfers/globus.py
@@ -74,23 +74,28 @@ class GlobusAsyncTransferManager(CoreAsyncTransferManager):
 
         if settings.globus_client_native_app:
             try:
-                client = globus_sdk.NativeAppAuthClient(settings.globus_client_id)
+                client = globus_sdk.NativeAppAuthClient(
+                    client_id=settings.globus_client_id
+                )
                 authorizer = globus_sdk.RefreshTokenAuthorizer(
-                    settings.globus_client_secret, client
+                    refresh_token=settings.globus_client_secret, auth_client=client
                 )
             except globus_sdk.AuthAPIError as e:
                 return None
         else:
             try:
                 client = globus_sdk.ConfidentialAppAuthClient(
-                    settings.globus_client_id, settings.globus_client_secret
+                    client_id=settings.globus_client_id,
+                    client_secret=settings.globus_client_secret,
                 )
                 tokens = client.oauth2_client_credentials_tokens()
                 transfer_tokens_info = tokens.by_resource_server[
                     "transfer.api.globus.org"
                 ]
                 transfer_token = transfer_tokens_info["access_token"]
-                authorizer = globus_sdk.AccessTokenAuthorizer(transfer_token)
+                authorizer = globus_sdk.AccessTokenAuthorizer(
+                    access_token=transfer_token
+                )
             except globus_sdk.AuthAPIError as e:
                 return None
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "xxhash >= 0.8.0",
     "cryptography",
     "fastapi >= 0.108.0",
-    "globus-sdk <= 3.40.0",
+    "globus-sdk",
     "httpx",
     "pydantic >= 2",
     "pydantic-settings >= 2",


### PR DESCRIPTION
This PR changes how the Librarian interacts with Globus by always creating a new instance of the authorizer object for a transfer rather than storing it on the object.

Fixes #78.