### PR TITLE
Add ability to shut down external transfers using client/cli scripts

### DIFF
--- a/alembic/versions/1def8c988372_add_librarian_transfer_toggling.py
+++ b/alembic/versions/1def8c988372_add_librarian_transfer_toggling.py
@@ -1,0 +1,29 @@
+# Copyright 2017 the HERA Collaboration
+# Licensed under the 2-clause BSD License.
+
+"""Add librarian transfer toggling
+
+Revision ID: 1def8c988372
+Revises: 42f29c26ab0f
+Create Date: 2024-11-11 15:09:12.578181
+
+"""
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "1def8c988372"
+down_revision = "42f29c26ab0f"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("librarians") as batch_op:
+        batch_op.add_column(
+            sa.Column("transfers_enabled", sa.Boolean(), nullable=False, default=True)
+        )
+
+
+def downgrade():
+    op.drop_column("librarians", "transfers_enabled")

--- a/hera_librarian/models/admin.py
+++ b/hera_librarian/models/admin.py
@@ -167,6 +167,9 @@ class LibrarianListResponseItem(BaseModel):
     available: bool | None
     "Whether the librarian is available or not, only if ping is true."
 
+    enabled: bool
+    "Whether transfers the librarian is enabled or not."
+
 
 class AdminListLibrariansResponse(BaseModel):
     librarians: list[LibrarianListResponseItem]
@@ -238,3 +241,28 @@ class AdminDeleteInstanceResponse(BaseModel):
 
     "The instance name of the instance that was changed."
     instance_id: int
+
+
+class AdminChangeLibrarianTransferStatusRequest(BaseModel):
+    """
+    A request to change the transfer status of a librarian, either
+    to enable or disable outbound transfers.
+    """
+
+    "The name of the librarian to change the transfer status of."
+    librarian_name: str
+
+    "Whether to enable or disable outbound transfers."
+    transfers_enabled: bool
+
+
+class AdminLibrarianTransferStatusResponse(BaseModel):
+    """
+    A response to a user change request.
+    """
+
+    "The name of the librarian that was changed."
+    librarian_name: str
+
+    "Whether the librarian has outbound transfers enabled."
+    transfers_enabled: bool

--- a/librarian_background/send_clone.py
+++ b/librarian_background/send_clone.py
@@ -479,6 +479,12 @@ class SendClone(Task):
             )
             return CancelJob
 
+        if not librarian.transfers_enabled:
+            logger.warning(
+                f"Transfers to librarian {librarian.name} are temporarily disabled, skipping."
+            )
+            return
+
         client: "LibrarianClient" = librarian.client()
 
         try:

--- a/librarian_server/api/admin.py
+++ b/librarian_server/api/admin.py
@@ -16,10 +16,12 @@ from hera_librarian.exceptions import LibrarianHTTPError
 from hera_librarian.models.admin import (
     AdminAddLibrarianRequest,
     AdminAddLibrarianResponse,
+    AdminChangeLibrarianTransferStatusRequest,
     AdminCreateFileRequest,
     AdminCreateFileResponse,
     AdminDeleteInstanceRequest,
     AdminDeleteInstanceResponse,
+    AdminLibrarianTransferStatusResponse,
     AdminListLibrariansRequest,
     AdminListLibrariansResponse,
     AdminRemoveLibrarianRequest,
@@ -388,6 +390,7 @@ def list_librarians(
                 url=librarian.url,
                 port=librarian.port,
                 available=ping if request.ping else None,
+                enabled=librarian.transfers_enabled,
             )
         )
 
@@ -581,3 +584,39 @@ def delete_local_instance(
         store.store_manager.delete(Path(instance.path))
 
     return AdminDeleteInstanceResponse(success=True, instance_id=request.instance_id)
+
+
+@router.post(
+    path="/librarians/transfer_status/change",
+    response_model=AdminLibrarianTransferStatusResponse,
+)
+def change_librarian_transfer_status(
+    request: AdminChangeLibrarianTransferStatusRequest,
+    user: AdminUserDependency,
+    response: Response,
+    session: Session = Depends(yield_session),
+) -> AdminLibrarianTransferStatusResponse:
+    """
+    Change the transfer status of a librarian. This will enable or disable
+    outbound transfers to the librarian.
+    """
+
+    librarian = (
+        session.query(Librarian).filter_by(name=request.librarian_name).one_or_none()
+    )
+
+    if librarian is None:
+        response.status_code = status.HTTP_400_BAD_REQUEST
+        return AdminRequestFailedResponse(
+            reason=f"Librarian {request.librarian_name} does not exist",
+            suggested_remedy="Check for typos in your request",
+        )
+
+    librarian.transfers_enabled = request.transfers_enabled
+
+    session.commit()
+
+    return AdminLibrarianTransferStatusResponse(
+        librarian_name=librarian.name,
+        transfers_enabled=librarian.transfers_enabled,
+    )

--- a/librarian_server/orm/librarian.py
+++ b/librarian_server/orm/librarian.py
@@ -36,6 +36,7 @@ class Librarian(db.Base):
     "The port of this librarian."
     authenticator = db.Column(db.String(256), nullable=False)
     "The authenticator so we can connect this librarian. This is encrypted."
+    transfers_enabled = db.Column(db.Boolean, nullable=False, default=True)
 
     last_seen = db.Column(db.DateTime, nullable=False)
     "The last time we connected to and verified this librarian exists."

--- a/librarian_server/settings.py
+++ b/librarian_server/settings.py
@@ -87,10 +87,10 @@ class ServerSettings(BaseSettings):
 
     # Host and port to bind to.
     host: str = "0.0.0.0"
-    port: int
+    port: int = 8080
 
     # Stores that the librarian should add or migrate
-    add_stores: list[StoreSettings]
+    add_stores: list[StoreSettings] = []
 
     # Database migration settings
     alembic_config_path: str = "."

--- a/librarian_server_scripts/librarian_change_transfer_status.py
+++ b/librarian_server_scripts/librarian_change_transfer_status.py
@@ -1,0 +1,58 @@
+"""
+A command-line script, for use in containers, to change the behaviour
+of transfers to external librarians.
+"""
+
+import argparse as ap
+
+parser = ap.ArgumentParser(
+    description=(
+        "Change the status of an external librarian, to enable or disable transfers."
+    )
+)
+
+parser.add_argument(
+    "--librarian",
+    help="Name of the librarian to change the status of.",
+    type=str,
+    required=True,
+)
+
+parser.add_argument(
+    "--enable",
+    help="Enable the librarian.",
+    action="store_true",
+)
+
+parser.add_argument(
+    "--disable",
+    help="Disable the librarian.",
+    action="store_true",
+)
+
+
+def main():
+    args = parser.parse_args()
+
+    if args.enable and args.disable:
+        raise ValueError("Cannot enable and disable at the same time.")
+
+    if not args.enable and not args.disable:
+        raise ValueError("Must enable or disable.")
+
+    from librarian_server.database import get_session
+    from librarian_server.orm import Librarian
+
+    with get_session() as session:
+        librarian = (
+            session.query(Librarian).filter_by(name=args.librarian).one_or_none()
+        )
+        if librarian is None:
+            raise ValueError(f"Librarian {args.librarian} does not exist.")
+
+        if args.enable:
+            librarian.transfers_enabled = True
+        elif args.disable:
+            librarian.transfers_enabled = False
+
+        session.commit()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,7 @@ librarian-server-setup = "librarian_server_scripts.librarian_server_setup:main"
 librarian = "hera_librarian.cli:main"
 librarian-server-rebuild-database = "librarian_server_scripts.librarian_server_rebuild_database:main"
 librarian-server-repair-database = "librarian_server_scripts.librarian_server_repair_database:main"
+librarian-change-transfer-status = "librarian_server_scripts.librarian_change_transfer_status:main"
 
 [project.urls]
 Homepage = "https://github.com/simonsobs/librarian"

--- a/tests/server_unit_test/test_admin.py
+++ b/tests/server_unit_test/test_admin.py
@@ -8,6 +8,7 @@ from hera_librarian.deletion import DeletionPolicy
 from hera_librarian.models.admin import (
     AdminAddLibrarianRequest,
     AdminAddLibrarianResponse,
+    AdminChangeLibrarianTransferStatusRequest,
     AdminCreateFileRequest,
     AdminCreateFileResponse,
     AdminListLibrariansRequest,
@@ -352,6 +353,19 @@ def test_add_librarians(test_client, test_server_with_valid_file, test_orm):
     assert response.success == False
     assert response.already_exists == True
 
+    # Now disable this guy!
+    disable_request = AdminChangeLibrarianTransferStatusRequest(
+        librarian_name="our_closest_friend",
+        transfers_enabled=False,
+    )
+
+    response = test_client.post_with_auth(
+        "/api/v2/admin/librarians/transfer_status/change",
+        content=disable_request.model_dump_json(),
+    )
+
+    assert response.status_code == 200
+
     # Now we can try the search endpoint.
     search_request = AdminListLibrariansRequest(
         ping=False,
@@ -371,6 +385,7 @@ def test_add_librarians(test_client, test_server_with_valid_file, test_orm):
             assert librarian.url == "http://localhost"
             assert librarian.port == 80
             assert librarian.available == None
+            assert librarian.enabled == False
             found = True
 
     assert found


### PR DESCRIPTION
This will help us avoid needless restarts of the server when we just want to edit the basic 'on/off' functionality of external transfers.