### PR TITLE
release runs only when a release is published

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,13 +2,16 @@ name: release
 on:
   release:
     types: [published]
-  workflow_run:
-    workflows: ["Formatting", "Tests"]
-    types:
-      - completed
 
 jobs:
-  release:
+  independent-job:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Perform independent task
+        run: echo "This job runs independently of other jobs."
+  release-job:
+    needs: ["Formatting", "Tests"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
It closes #120 

It runs only on releases and waits for the other two workflows to finish. It seems that Github requires at least one independent job per workflow, so I added a dummy one.