### PR TITLE
Make request timeouts effective, and fail validation when a downstream is unreachable

### DIFF
--- a/hera_librarian/client.py
+++ b/hera_librarian/client.py
@@ -156,6 +156,8 @@ class LibrarianClient:
             port=client_info.port,
             user=client_info.user,
             password=client_info.password,
+            checksum_threads=client_info.checksum_threads,
+            request_timeout_seconds=client_info.request_timeout_seconds,
         )
 
     @property
@@ -242,7 +244,11 @@ class LibrarianClient:
                 auth=(self.user, self.password),
                 timeout=self.request_timeout_seconds,
             )
-        except (TimeoutError, requests.exceptions.ConnectionError):
+        except (
+            TimeoutError,
+            requests.exceptions.Timeout,
+            requests.exceptions.ConnectionError,
+        ):
             raise LibrarianTimeoutError(url=self.resolve(endpoint))
 
         if str(r.status_code)[0] != "2":
@@ -568,7 +574,15 @@ class AdminClient(LibrarianClient):
     A client for the Librarian API with admin privileges.
     """
 
-    def __init__(self, host: str, port: int, user: str, password: str):
+    def __init__(
+        self,
+        host: str,
+        port: int,
+        user: str,
+        password: str,
+        checksum_threads: int = 1,
+        request_timeout_seconds: int | None = None,
+    ):
         """
         Create a new AdminClient.
 
@@ -584,7 +598,9 @@ class AdminClient(LibrarianClient):
             The password of the user.
         """
 
-        super().__init__(host, port, user, password)
+        super().__init__(
+            host, port, user, password, checksum_threads, request_timeout_seconds
+        )
 
     def __repr__(self):
         return f"Admin Client ({self.user}) for {self.host}:{self.port}"

--- a/hera_librarian/client.py
+++ b/hera_librarian/client.py
@@ -25,7 +25,12 @@ from hera_librarian.models.clone import (
 from .authlevel import AuthLevel
 from .deletion import DeletionPolicy
 from .errors import ErrorCategory, ErrorSeverity
-from .exceptions import LibrarianError, LibrarianHTTPError, LibrarianTimeoutError
+from .exceptions import (
+    LibrarianError,
+    LibrarianHTTPError,
+    LibrarianTimeoutError,
+    LibrarianDownstreamUnavailableError,
+)
 from .models.admin import (
     AdminAddLibrarianRequest,
     AdminAddLibrarianResponse,
@@ -560,11 +565,23 @@ class LibrarianClient:
             ``.computed_same_checksum`` among additional information.
         """
 
-        response = self.post(
-            endpoint="validate/file",
-            request=FileValidationRequest(file_name=file_name),
-            response=FileValidationResponse,
-        )
+        try:
+            response = self.post(
+                endpoint="validate/file",
+                request=FileValidationRequest(file_name=file_name),
+                response=FileValidationResponse,
+            )
+        except LibrarianHTTPError as e:
+            if e.status_code == 503:
+                # The librarian could not reach one of its downstreams. Its
+                # answer would be incomplete, and silently treating that as
+                # "no remote copies" is how data gets deleted that shouldn't be.
+                raise LibrarianDownstreamUnavailableError(
+                    url=self.hostname,
+                    reason=e.reason,
+                    suggested_remedy=e.suggested_remedy,
+                ) from e
+            raise
 
         return response.root
 

--- a/hera_librarian/client.py
+++ b/hera_librarian/client.py
@@ -93,7 +93,13 @@ class LibrarianClient:
     checksum_threads: int = 1
 
     def __init__(
-        self, host: str, port: int, user: str, password: str, checksum_threads: int = 1
+        self,
+        host: str,
+        port: int,
+        user: str,
+        password: str,
+        checksum_threads: int = 1,
+        request_timeout_seconds: int | None = None,
     ):
         """
         Create a new LibrarianClient.
@@ -110,6 +116,9 @@ class LibrarianClient:
             The password of the user.
         checksum_threads : int
             The number of threads to use for checksum computation. Default is 1.
+        request_timeout_seconds : int | None = 1800
+            The timeout for requests in seconds. If None, no timeout is set, default
+            is 30 minutes.
         """
 
         if host[-1] == "/":
@@ -121,6 +130,7 @@ class LibrarianClient:
         self.user = user
         self.password = password
         self.checksum_threads = checksum_threads
+        self.request_timeout_seconds = request_timeout_seconds
 
     def __repr__(self):
         return f"Librarian Client ({self.user}) for {self.host}:{self.port}"
@@ -230,6 +240,7 @@ class LibrarianClient:
                 data=data,
                 headers={"Content-Type": "application/json"},
                 auth=(self.user, self.password),
+                timeout=self.request_timeout_seconds,
             )
         except (TimeoutError, requests.exceptions.ConnectionError):
             raise LibrarianTimeoutError(url=self.resolve(endpoint))

--- a/hera_librarian/exceptions.py
+++ b/hera_librarian/exceptions.py
@@ -33,3 +33,22 @@ class LibrarianClientRemovedFunctionality(Exception):
         super(LibrarianClientRemovedFunctionality, self).__init__(
             f"{name} is no longer avaialble in Librarian v2.0. {message}"
         )
+
+
+class LibrarianDownstreamUnavailableError(Exception):
+    """
+    Raised when a librarian could not contact one of its downstream librarians
+    while answering our request, so its answer would have been incomplete.
+
+    This is distinct from a librarian telling us that a file has no remote
+    copies: here, we simply do not know.
+    """
+
+    def __init__(self, url, reason, suggested_remedy=None):
+        super().__init__(
+            f"The librarian at {url} could not reach a downstream librarian, so "
+            f"its answer is incomplete. {reason}"
+        )
+        self.url = url
+        self.reason = reason
+        self.suggested_remedy = suggested_remedy

--- a/hera_librarian/settings.py
+++ b/hera_librarian/settings.py
@@ -26,6 +26,10 @@ class ClientInfo(BaseModel):
     "The hostname of this librarian server"
     password: str
     "Your password on this librarian"
+    checksum_threads: int = 1
+    "The number of threads to use for checksum computation. Default is 1."
+    request_timeout_seconds: int | None = 1800
+    "The timeout for requests in seconds. If None, no timeout is set."
 
 
 class ClientSettings(BaseSettings):

--- a/librarian_server/api/validate.py
+++ b/librarian_server/api/validate.py
@@ -36,6 +36,19 @@ from .auth import ReadonlyUserDependency
 router = APIRouter(prefix="/api/v2/validate")
 
 
+class DownstreamUnreachableError(Exception):
+    """
+    Raised internally when a downstream librarian cannot be contacted while
+    servicing a validation request. The result we could return would be
+    incomplete, and indistinguishable from "that librarian holds no copies",
+    so we refuse to answer instead.
+    """
+
+    def __init__(self, librarian_name: str):
+        super().__init__(f"Unable to contact downstream librarian {librarian_name}.")
+        self.librarian_name = librarian_name
+
+
 def calculate_checksum_of_local_copy(
     original_checksum: str,
     original_size: int,
@@ -84,9 +97,9 @@ def calculate_checksum_of_remote_copies(
     try:
         client = librarian.client()
         client.ping()
-    except (LibrarianError, LibrarianHTTPError, LibrarianTimeoutError):
+    except (LibrarianError, LibrarianHTTPError, LibrarianTimeoutError) as e:
         log.error(f"Unable to contact downstream librarian {librarian.name}")
-        return []
+        raise DownstreamUnreachableError(librarian.name) from e
 
     try:
         responses = client.validate_file(file_name)
@@ -98,11 +111,11 @@ def calculate_checksum_of_remote_copies(
         )
 
         return responses
-    except (LibrarianHTTPError, LibrarianError, LibrarianTimeoutError):
+    except (LibrarianHTTPError, LibrarianError, LibrarianTimeoutError) as e:
         log.error(
             f"Failed to validate file {file_name} with librarian {librarian.name}"
         )
-        return []
+        raise DownstreamUnreachableError(librarian.name) from e
 
 
 @router.post(
@@ -192,7 +205,33 @@ async def validate_file(
 
         coroutines.append(this_checksum_info)
 
-    checksum_info = await asyncio.gather(*coroutines)
+    # return_exceptions=True so that we wait for every branch to finish before
+    # returning. Letting an exception propagate out of gather() leaves the other
+    # coroutines running against a session that is about to be torn down.
+    results = await asyncio.gather(*coroutines, return_exceptions=True)
+
+    unreachable = [r for r in results if isinstance(r, DownstreamUnreachableError)]
+
+    if unreachable:
+        names = ", ".join(sorted({e.librarian_name for e in unreachable}))
+        log.error(f"Refusing to validate {request.file_name}: cannot reach {names}")
+        response.status_code = status.HTTP_503_SERVICE_UNAVAILABLE
+        return FileValidationFailedResponse(
+            reason=(
+                f"Unable to contact downstream librarian(s) {names}, so the set "
+                "of valid copies of this file cannot be determined."
+            ),
+            suggested_remedy=(
+                "Retry once the downstream librarian is reachable. Do not treat "
+                "this as the file having no remote copies."
+            ),
+        )
+
+    for result in results:
+        if isinstance(result, BaseException):
+            raise result
+
+    checksum_info = results
 
     # Flatten checksum_info
     checksum_info = [item for sublist in checksum_info for item in sublist]

--- a/librarian_server/orm/librarian.py
+++ b/librarian_server/orm/librarian.py
@@ -12,6 +12,7 @@ from hera_librarian.exceptions import LibrarianHTTPError
 
 from .. import database as db
 from ..encryption import decrypt_string, encrypt_string
+from ..settings import server_settings
 
 
 class Librarian(db.Base):
@@ -127,4 +128,5 @@ class Librarian(db.Base):
             port=self.port,
             user=decrpyted_authenticator.split(":")[0],
             password=decrpyted_authenticator.split(":")[1],
+            request_timeout_seconds=server_settings.librarian_request_timeout_seconds,
         )

--- a/librarian_server/settings.py
+++ b/librarian_server/settings.py
@@ -156,6 +156,9 @@ class ServerSettings(BaseSettings):
     # a specific destination.
     max_async_inflight_transfers: int = 64
 
+    # Timout, in seconds, for HTTP requests made to other librarians
+    librarian_request_timeout_seconds: Optional[int] = 1800
+
     # Log settings
     log_settings: LogSettings = Field(default_factory=LogSettings)
 

--- a/tests/client_unit_test/test_client_downstream_unavailable.py
+++ b/tests/client_unit_test/test_client_downstream_unavailable.py
@@ -1,0 +1,105 @@
+# -*- mode: python; coding: utf-8 -*-
+# Copyright 2019 the HERA Collaboration
+# Licensed under the 2-clause BSD License
+
+"""Test that a 503 from validate/file becomes a distinct exception.
+
+When a librarian cannot reach one of its downstreams it answers 503 rather
+than returning a partial list. The client must turn that into
+LibrarianDownstreamUnavailableError, so callers can tell "I could not check"
+apart from "there are no remote copies".
+
+"""
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import pytest
+
+from hera_librarian.client import LibrarianClient
+from hera_librarian.exceptions import (
+    LibrarianDownstreamUnavailableError,
+    LibrarianHTTPError,
+)
+
+REASON = "Unable to contact downstream librarian downstream_a."
+REMEDY = "Retry once the downstream librarian is reachable."
+
+
+def _make_handler(status_code, body):
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self):
+            payload = json.dumps(body).encode()
+            self.send_response(status_code)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+
+        def log_message(self, *args):
+            pass
+
+    return Handler
+
+
+@pytest.fixture
+def failing_server(request):
+    """A server that answers every POST with a given status and body."""
+
+    status_code, body = request.param
+
+    server = HTTPServer(("127.0.0.1", 0), _make_handler(status_code, body))
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    yield server.server_address[1]
+
+    server.shutdown()
+    server.server_close()
+
+
+def client_for(port):
+    return LibrarianClient(
+        host="http://127.0.0.1",
+        port=port,
+        user="user",
+        password="password",
+        request_timeout_seconds=5,
+    )
+
+
+@pytest.mark.parametrize(
+    "failing_server",
+    [(503, {"reason": REASON, "suggested_remedy": REMEDY})],
+    indirect=True,
+)
+def test_503_becomes_downstream_unavailable(failing_server):
+    """A 503 must not surface as a generic HTTP error."""
+
+    client = client_for(failing_server)
+
+    with pytest.raises(LibrarianDownstreamUnavailableError) as excinfo:
+        client.validate_file("example_file.txt")
+
+    assert "downstream_a" in excinfo.value.reason
+    assert excinfo.value.suggested_remedy == REMEDY
+
+    return
+
+
+@pytest.mark.parametrize(
+    "failing_server",
+    [(400, {"reason": "no such file", "suggested_remedy": "check the name"})],
+    indirect=True,
+)
+def test_other_errors_are_unchanged(failing_server):
+    """Other failures must keep raising LibrarianHTTPError. This is the
+    control: it shows we narrowed the new behaviour to 503 only."""
+
+    client = client_for(failing_server)
+
+    with pytest.raises(LibrarianHTTPError):
+        client.validate_file("example_file.txt")
+
+    return

--- a/tests/client_unit_test/test_client_timeout.py
+++ b/tests/client_unit_test/test_client_timeout.py
@@ -1,0 +1,145 @@
+# -*- mode: python; coding: utf-8 -*-
+# Copyright 2019 the HERA Collaboration
+# Licensed under the 2-clause BSD License
+
+"""Test timeout handling in hera_librarian/client.py
+
+Covers two things:
+
+- that network failures are translated into LibrarianTimeoutError, for both
+  kinds of timeout that requests can raise
+- that timeout settings survive the trip from ClientInfo through from_info()
+
+"""
+
+import socket
+import threading
+import time
+
+import pytest
+
+from hera_librarian.client import LibrarianClient
+from hera_librarian.exceptions import LibrarianTimeoutError
+from hera_librarian.settings import ClientInfo
+
+# Short enough to keep the suite fast, long enough not to be flaky.
+TEST_TIMEOUT_SECONDS = 2
+
+
+@pytest.fixture
+def stalling_port():
+    """A local port that accepts connections and then never responds.
+
+    Simulates a librarian whose process is wedged: the TCP handshake
+    succeeds, so this is not a connection failure, but no HTTP response
+    ever arrives.
+    """
+
+    listener = socket.socket()
+    listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    listener.bind(("127.0.0.1", 0))
+    listener.listen(5)
+
+    held = []
+    stop = threading.Event()
+
+    def accept_and_stall():
+        while not stop.is_set():
+            try:
+                conn, _ = listener.accept()
+                held.append(conn)
+            except OSError:
+                return
+
+    thread = threading.Thread(target=accept_and_stall, daemon=True)
+    thread.start()
+
+    yield listener.getsockname()[1]
+
+    stop.set()
+    listener.close()
+    for conn in held:
+        conn.close()
+
+
+@pytest.fixture
+def refusing_port():
+    """A local port with nothing listening on it at all."""
+
+    probe = socket.socket()
+    probe.bind(("127.0.0.1", 0))
+    port = probe.getsockname()[1]
+    probe.close()
+
+    return port
+
+
+def client_for(port):
+    """A client pointed at a local port, with an explicit short timeout."""
+
+    return LibrarianClient(
+        host="http://127.0.0.1",
+        port=port,
+        user="user",
+        password="password",
+        request_timeout_seconds=TEST_TIMEOUT_SECONDS,
+    )
+
+
+def test_connection_refused_raises_librarian_timeout(refusing_port):
+    """A refused connection should surface as LibrarianTimeoutError."""
+
+    client = client_for(refusing_port)
+
+    with pytest.raises(LibrarianTimeoutError):
+        client.ping()
+
+    return
+
+
+def test_read_timeout_raises_librarian_timeout(stalling_port):
+    """A server that accepts and then stalls should also surface as
+    LibrarianTimeoutError, not as a raw requests exception."""
+
+    client = client_for(stalling_port)
+
+    with pytest.raises(LibrarianTimeoutError):
+        client.ping()
+
+    return
+
+
+def test_from_info_passes_request_timeout():
+    """request_timeout_seconds set in config should reach the client."""
+
+    info = ClientInfo(
+        user="user",
+        port=1234,
+        host="http://127.0.0.1",
+        password="password",
+        request_timeout_seconds=60,
+    )
+
+    client = LibrarianClient.from_info(info)
+
+    assert client.request_timeout_seconds == 60
+
+    return
+
+
+def test_from_info_passes_checksum_threads():
+    """checksum_threads set in config should reach the client."""
+
+    info = ClientInfo(
+        user="user",
+        port=1234,
+        host="http://127.0.0.1",
+        password="password",
+        checksum_threads=8,
+    )
+
+    client = LibrarianClient.from_info(info)
+
+    assert client.checksum_threads == 8
+
+    return

--- a/tests/server_unit_test/test_librarian_client_timeout.py
+++ b/tests/server_unit_test/test_librarian_client_timeout.py
@@ -1,0 +1,66 @@
+# -*- mode: python; coding: utf-8 -*-
+# Copyright 2019 the HERA Collaboration
+# Licensed under the 2-clause BSD License
+
+"""Test that Librarian.client() applies the configured request timeout.
+
+Without a timeout, a call to a librarian that accepts the connection and then
+stops responding will wait forever, which stalls the validate fan-out.
+
+Note that librarian_server imports are deliberately made inside the functions
+below. server_settings is a lazily-loaded singleton, and importing it at module
+scope forces it to load during test collection, before the fixtures that
+configure it have run.
+
+"""
+
+from datetime import datetime, timezone
+
+from cryptography.fernet import Fernet
+
+
+def _librarian():
+    """An in-memory Librarian row. Not attached to a session."""
+
+    from librarian_server.encryption import encrypt_string
+    from librarian_server.orm.librarian import Librarian
+
+    return Librarian(
+        name="downstream",
+        url="http://localhost",
+        port=1234,
+        authenticator=encrypt_string("user:password"),
+        last_seen=datetime.now(timezone.utc),
+        last_heard=datetime.now(timezone.utc),
+    )
+
+
+def test_client_uses_configured_timeout(monkeypatch):
+    """The server setting should reach the client we build for a remote
+    librarian."""
+
+    from librarian_server.settings import server_settings
+
+    monkeypatch.setattr(
+        server_settings, "encryption_key", Fernet.generate_key().decode()
+    )
+    monkeypatch.setattr(server_settings, "librarian_request_timeout_seconds", 42)
+
+    assert _librarian().client().request_timeout_seconds == 42
+
+    return
+
+
+def test_client_timeout_defaults_to_a_real_value(monkeypatch):
+    """Out of the box the timeout must not be None, which requests treats as
+    "wait forever"."""
+
+    from librarian_server.settings import server_settings
+
+    monkeypatch.setattr(
+        server_settings, "encryption_key", Fernet.generate_key().decode()
+    )
+
+    assert _librarian().client().request_timeout_seconds is not None
+
+    return

--- a/tests/server_unit_test/test_validation.py
+++ b/tests/server_unit_test/test_validation.py
@@ -76,3 +76,66 @@ def test_validate_file_not_found(test_server, test_client):
     )
 
     assert response.status_code == 400
+
+
+def test_validate_file_downstream_unreachable(
+    test_server_with_valid_file, test_client, test_orm
+):
+    """A downstream we cannot contact must not be reported as holding no
+    copies. The endpoint should refuse to answer instead."""
+
+    import socket
+    from datetime import datetime, timezone
+
+    from librarian_server.encryption import encrypt_string
+
+    # Pick a port with nothing listening on it.
+    probe = socket.socket()
+    probe.bind(("127.0.0.1", 0))
+    dead_port = probe.getsockname()[1]
+    probe.close()
+
+    session = test_server_with_valid_file[1]()
+
+    librarian = test_orm.Librarian(
+        name="unreachable_librarian",
+        url="http://localhost",
+        port=dead_port,
+        authenticator=encrypt_string("user:password"),
+        last_seen=datetime.now(timezone.utc),
+        last_heard=datetime.now(timezone.utc),
+    )
+    session.add(librarian)
+    session.commit()
+
+    remote_instance = test_orm.RemoteInstance(
+        file_name="example_file.txt",
+        store_id=1,
+        librarian_id=librarian.id,
+        copy_time=datetime.now(timezone.utc),
+        sender="test_server",
+    )
+    session.add(remote_instance)
+    session.commit()
+
+    remote_instance_id = remote_instance.id
+    librarian_id = librarian.id
+    session.close()
+
+    request = FileValidationRequest(file_name="example_file.txt")
+
+    response = test_client.post_with_auth(
+        "/api/v2/validate/file", content=request.model_dump_json()
+    )
+
+    assert response.status_code == 503
+    assert "unreachable_librarian" in response.json()["reason"]
+
+    # Clean up so we do not affect other tests.
+    session = test_server_with_valid_file[1]()
+    session.delete(session.get(test_orm.RemoteInstance, remote_instance_id))
+    session.delete(session.get(test_orm.Librarian, librarian_id))
+    session.commit()
+    session.close()
+
+    return


### PR DESCRIPTION
Builds on add-post-timeout. Fixes the three places request_timeout_seconds never reached a client, and makes validate/file return 503 with a new LibrarianDownstreamUnavailableError instead of silently reporting zero copies when a downstream is unreachable.

Two things for you: I used a ServerSettings field rather than the librarians table column so there is no migration - say if you would rather have the column. And one unreachable downstream currently fails the whole request.

Note: sotodlib still swallows the new exception in check_book_in_librarian.